### PR TITLE
Flash

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -339,6 +339,9 @@ public partial class App : Application
             return;
         }
 
+        // 单击托盘图标：立即播放电量预览（真实电池数据，完整三态动画），同时弹出菜单
+        _ = TriggerHudAsync();
+
         _trayMenu = new TrayMenuWindow();
         _trayMenu.PreviewClicked += () => { _trayMenu.Close(); _ = TriggerHudAsync(); };
         _trayMenu.SettingsClicked += () => { _trayMenu.Close(); OpenSettingsWindow(); };

--- a/Localization.cs
+++ b/Localization.cs
@@ -73,7 +73,7 @@ public static class Localization
     public static string MonitorName(int index, bool isPrimary) => IsChinese
         ? isPrimary ? $"显示器 {index + 1}（主）" : $"显示器 {index + 1}"
         : isPrimary ? $"Monitor {index + 1} (Primary)" : $"Monitor {index + 1}";
-    public static string MonitorDefault => IsChinese ? "默认" : "Default";
+    public static string MonitorPrimaryDefault => IsChinese ? "主显示器（默认）" : "Primary Monitor (Default)";
 
     // ---- 动画页 ----
     public static string TabAnimation => IsChinese ? "动画" : "Animation";

--- a/Settings/AppSettings.cs
+++ b/Settings/AppSettings.cs
@@ -17,7 +17,9 @@ public sealed record AppSettings
     public double RippleSpread { get; init; } = 1.0;
 
     public HudPosition HudPosition { get; init; } = HudPosition.TopCenter;
-    public int MonitorIndex { get; init; } = 0;
+
+    /// HUD 所在显示器：-1 => 主显示器（默认）。
+    public int MonitorIndex { get; init; } = -1;
     public string Language { get; init; } = "auto";
     public int LowBatteryThreshold { get; init; } = 20;
     public bool EnableLowBatteryAlert { get; init; } = true;

--- a/Settings/SettingsWindow.axaml.cs
+++ b/Settings/SettingsWindow.axaml.cs
@@ -201,6 +201,14 @@ public partial class SettingsWindow : Window
     {
         var screens = Screens.All;
         MonitorCombo.Items.Clear();
+
+        // 第一项：主显示器（默认），MonitorIndex 存 -1
+        MonitorCombo.Items.Add(new ComboBoxItem
+        {
+            Content = Localization.MonitorPrimaryDefault,
+            Tag = -1,
+        });
+
         for (int i = 0; i < screens.Count; i++)
         {
             var s = screens[i];
@@ -210,9 +218,6 @@ public partial class SettingsWindow : Window
                 Tag = i,
             });
         }
-
-        if (MonitorCombo.Items.Count == 0)
-            MonitorCombo.Items.Add(new ComboBoxItem { Content = Localization.MonitorDefault, Tag = 0 });
     }
 
     // ---------------- 加载 / 收集 ----------------
@@ -225,8 +230,10 @@ public partial class SettingsWindow : Window
         RippleIntensitySlider.Value = s.RippleIntensity;
         RippleSpreadSlider.Value = s.RippleSpread;
         PositionCombo.SelectedIndex = (int)s.HudPosition;
-        MonitorCombo.SelectedIndex = s.MonitorIndex >= 0 && s.MonitorIndex < MonitorCombo.Items.Count
-            ? s.MonitorIndex
+        // 下拉第一项是「主显示器（默认）」(-1)，物理显示器 i 对应下拉第 i+1 项
+        int monitorSel = s.MonitorIndex < 0 ? 0 : s.MonitorIndex + 1;
+        MonitorCombo.SelectedIndex = monitorSel >= 0 && monitorSel < MonitorCombo.Items.Count
+            ? monitorSel
             : 0;
 
         LanguageCombo.SelectedIndex = s.Language switch

--- a/Views/HudWindow.axaml.cs
+++ b/Views/HudWindow.axaml.cs
@@ -391,9 +391,7 @@ public partial class HudWindow : Window
 
     private void PositionTopCenter()
     {
-        var screens = Screens.All;
-        int idx = Math.Clamp(_settings.MonitorIndex, 0, screens.Count - 1);
-        var screen = screens.Count > idx ? screens[idx] : (Screens.Primary ?? screens.FirstOrDefault());
+        var screen = ResolveScreen(_settings.MonitorIndex);
         if (screen is null) return;
 
         var area = screen.WorkingArea;
@@ -410,6 +408,23 @@ public partial class HudWindow : Window
         };
 
         Position = new PixelPoint(x, area.Y + 4);
+    }
+
+    /// <summary>
+    /// 解析目标显示器：-1 = 主显示器（默认），0..N-1 = 显示器列表索引，越界退回主显示器。
+    /// </summary>
+    private Avalonia.Platform.Screen? ResolveScreen(int monitorIndex)
+    {
+        var screens = Screens.All;
+        var primary = Screens.Primary;
+
+        if (monitorIndex < 0)
+            return primary ?? screens.FirstOrDefault();
+
+        if (monitorIndex < screens.Count)
+            return screens[monitorIndex];
+
+        return primary ?? screens.FirstOrDefault();
     }
 
     private void ShowPositioned()


### PR DESCRIPTION
1. feat: 点击托盘区图标将直接显示电量
    提升用户交互便捷性，只需要在托盘区点击图标即可显示电量hub，而无需先打开菜单再点击显示。

3. fix(hud): 多显示器下电量hub默认定位于主显示器
    修复多显示器环境下 HUD 显示位置错误的问题，现在会自动识别主显示器并定位 ，假设你有两个显示屏，设置界面会显示：主显示器（默认）；显示器1；显示器2（主）
